### PR TITLE
doc: warn if VirtualBox loaded kernel extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # CoreOS + xhyve
 
-**WARNING**: xhyve is a very new project, expect bugs! You must be running OS X Yosemite for this to work.
+**WARNING**: xhyve is a very new project, expect bugs! You must be running OS X
+Yosemite for this to work. If you have VirtualBox or other virtualization
+software installed, xhyve may crash your system due to conflicting usages of the
+OS-level virtualization primitives. See mist64/xhyve#5 and mist64/xhyve#9.
 
 ## Step by Step Instructions
 

--- a/coreos-xhyve-fetch
+++ b/coreos-xhyve-fetch
@@ -158,4 +158,13 @@ INITRD=coreos_production_pxe_image.cpio.gz
 get $VMLINUZ
 get $INITRD
 
-
+kextstat | grep VBox && {
+  echo
+  echo
+  echo "** WARNING **"
+  echo "You have VirtualBox kernel extensions loaded, which might crash your"
+  echo "system if you attempt to start xhyve or run coreos-xhyve. This has been"
+  echo "reported to xhyve's maintainer here:"
+  echo
+  echo "https://github.com/mist64/xhyve/issues/9"
+}


### PR DESCRIPTION
Due to mist64/xhyve#9, following the README verbatim can (and just did,
in my case), fault the system into a hard reboot. Since there isn't a
lot of willingness upstream to address this in xhyve, the best we can do
is warn here before a user stumbles into data loss (like I just did).
