### PR TITLE
allow the ability to set persistent UUIDs for deterministic IP addressing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ through the following environment variables:
 - **MEMORY**  
   defaults to `1024`.  
   value is understood as being in MB.
+- **UUID**
+  defaults to a random *uuid*.  
+  set to a constant value in order to achieve the same IP address across VM reboots.
 - **CLOUD_CONFIG**  
   defaults to `https://raw.githubusercontent.com/coreos/coreos-xhyve/master/cloud-init/docker-only.txt`, and has to be a valid, reachable, URL,
   pointing to a valid *[cloud-config]

--- a/coreos-xhyve-run
+++ b/coreos-xhyve-run
@@ -11,6 +11,7 @@ fi
 VERSION=${VERSION:-${LATEST}}
 
 CLOUD_CONFIG=${CLOUD_CONFIG:-https://raw.githubusercontent.com/coreos/coreos-xhyve/master/cloud-init/docker-only.txt}
+UUID=${UUID:-$(uuidgen)} && UUID="-U ${UUID}"
 
 PAYLOAD=${CHANNEL}.${VERSION}.coreos_production_pxe
 VMLINUZ=${PAYLOAD}.vmlinuz
@@ -29,4 +30,4 @@ NET="-s 2:0,virtio-net"
 PCI_DEV="-s 0:0,hostbridge -s 31,lpc"
 LPC_DEV="-l com1,stdio"
 
-xhyve $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_HDD -f kexec,imgs/$VMLINUZ,imgs/$INITRD,"$CMDLINE"
+xhyve $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_HDD $UUID -f kexec,imgs/$VMLINUZ,imgs/$INITRD,"$CMDLINE"


### PR DESCRIPTION
- on top of #26 and #27, addresses #12 and overrides #24

(forked from coreos/coreos-xhyve#13)
