### PR TITLE
add the ability to pragmatically pass the ssh public key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ through the following environment variables:
 - **UUID**
   defaults to a random *uuid*.  
   set to a constant value in order to achieve the same IP address across VM reboots.
+- **SSHKEY**  
+  defaults to *none*
+  if set it will add, on startup, the given SSH public key to the *core*
+  user's authorized_keys file (it is usually in ~/.ssh/id_rsa.pub).  
+  ```
+  sudo coreos-xhyve-run SSHKEY="ssh-rsa AAAAB3...== x@y.z" ...
+  ```
 - **CLOUD_CONFIG**  
   defaults to `https://raw.githubusercontent.com/coreos/coreos-xhyve/master/cloud-init/docker-only.txt`, and has to be a valid, reachable, URL,
   pointing to a valid *[cloud-config]

--- a/coreos-xhyve-run
+++ b/coreos-xhyve-run
@@ -12,12 +12,13 @@ VERSION=${VERSION:-${LATEST}}
 
 CLOUD_CONFIG=${CLOUD_CONFIG:-https://raw.githubusercontent.com/coreos/coreos-xhyve/master/cloud-init/docker-only.txt}
 UUID=${UUID:-$(uuidgen)} && UUID="-U ${UUID}"
+[[ -n "${SSHKEY}" ]] && SSHKEY="sshkey=\"${SSHKEY}\""
 
 PAYLOAD=${CHANNEL}.${VERSION}.coreos_production_pxe
 VMLINUZ=${PAYLOAD}.vmlinuz
 INITRD=${PAYLOAD}_image.cpio.gz
 
-CMDLINE="earlyprintk=serial console=ttyS0 acpi=off coreos.autologin"
+CMDLINE="earlyprintk=serial console=ttyS0 acpi=off ${SSHKEY} coreos.autologin"
 
 if [ $# -ne 1 ]; then
     CMDLINE="${CMDLINE} cloud-config-url=${CLOUD_CONFIG}"


### PR DESCRIPTION
- on top of #26, #27 and #28 

(forked from coreos/coreos-xhyve#13)
