### PR TITLE
add the ability to set the number of CPUs, now that we can run CoreOS with SMP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ through the following environment variables:
   available alternatives are `stable` and `beta`
 - **VERSION**  
   defaults to `latest`.
+- **CPUS**  
+  defaults to `1`.
 - **MEMORY**  
   defaults to `1024`.  
   value is understood as being in MB.

--- a/coreos-xhyve-run
+++ b/coreos-xhyve-run
@@ -33,12 +33,13 @@ PAYLOAD=${CHANNEL}.${VERSION}.coreos_production_pxe
 VMLINUZ=${PAYLOAD}.vmlinuz
 INITRD=${PAYLOAD}_image.cpio.gz
 
-CMDLINE="earlyprintk=serial console=ttyS0 acpi=off ${SSHKEY} coreos.autologin"
+CMDLINE="earlyprintk=serial console=ttyS0 ${SSHKEY} coreos.autologin"
 CMDLINE="${CMDLINE} cloud-config-url=${CLOUD_CONFIG}"
 
 MEMORY=${MEMORY:-1024}
 MEM="-m ${MEMORY}M"
-#SMP="-c 2"
+CPUS=${CPUS:-1}
+SMP="-c ${CPUS} -A"
 NET="-s 2:0,virtio-net"
 PCI_DEV="-s 0:0,hostbridge -s 31,lpc"
 LPC_DEV="-l com1,stdio"


### PR DESCRIPTION
this (and SMP) works now given that [this](https://github.com/mist64/xhyve/commit/0e9d07db34b2d44618cf1e0f273ef199dbe82030) from @xez got merged in plain xhyve upstream tree last night, as _en passant_ it fixed a bunch of acpi woes that were preventing SMP to work with plain CoreOS.  
