### PR TITLE
README: Fix typo in dd example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ through the following environment variables:
 
   **creating a disk image**:
   ```
-  dd if=/dev/zero of=./xhyve.img bs=1M count=5000
+  dd if=/dev/zero of=./xhyve.img bs=1024k count=5000
   /usr/local/opt/e2fsprogs/sbin/mkfs.ext4 -L ROOT xhyve.img
   ```
   *note: this requires you to install e2fsprogs (`brew install e2fsprogs`)*


### PR DESCRIPTION
BSD dd will barf on an uppercase unit of measurement.

From the dd(1) man page:

> Where sizes are specified, a decimal, octal, or hexadecimal number of bytes is
> expected.  If the number ends with a `b`, `k`, `m`, `g`, or `w`, the number is
> multiplied by 512, 1024 (1K), 1048576 (1M), 1073741824 (1G) or the number of
> bytes in an integer, respectively.